### PR TITLE
🔧 Disable rules incompatible with Ruby 1.8 & 1.9

### DIFF
--- a/config/ruby-1.8.yml
+++ b/config/ruby-1.8.yml
@@ -1,0 +1,1 @@
+inherit_from: ./ruby-1.9.yml

--- a/config/ruby-1.9.yml
+++ b/config/ruby-1.9.yml
@@ -1,0 +1,14 @@
+inherit_from: ./ruby-2.0.yml
+
+# String#end_with? added in Ruby 2.0.0
+# https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-end_with-3F
+Performance/EndWith:
+  Enabled: false
+
+# String#start_with? added in Ruby 2.0.0
+# https://docs.ruby-lang.org/en/2.0.0/String.html#method-i-start_with-3F
+Performance/StartWith:
+  Enabled: false
+
+Performance/DoubleStartEndWith:
+  Enabled: false

--- a/config/ruby-2.0.yml
+++ b/config/ruby-2.0.yml
@@ -1,0 +1,1 @@
+inherit_from: ./ruby-2.1.yml

--- a/config/ruby-2.1.yml
+++ b/config/ruby-2.1.yml
@@ -1,0 +1,1 @@
+inherit_from: ./ruby-2.2.yml

--- a/lib/standard/performance/plugin.rb
+++ b/lib/standard/performance/plugin.rb
@@ -54,6 +54,14 @@ module Standard::Performance
 
       file_name = if !Gem::Version.correct?(desired_version)
         default
+      elsif desired_version < Gem::Version.new("1.9")
+        "ruby-1.8.yml"
+      elsif desired_version < Gem::Version.new("2.0")
+        "ruby-1.9.yml"
+      elsif desired_version < Gem::Version.new("2.1")
+        "ruby-2.0.yml"
+      elsif desired_version < Gem::Version.new("2.2")
+        "ruby-2.1.yml"
       elsif desired_version < Gem::Version.new("2.3")
         "ruby-2.2.yml"
       else

--- a/test/standard/performance/plugin_test.rb
+++ b/test/standard/performance/plugin_test.rb
@@ -9,7 +9,11 @@ module Standard::Performance
     def test_paths
       assert_match "base.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: RUBY_VERSION)).value.to_s
       assert_match "base.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("2.8.2"))).value.to_s
-      assert_match "ruby-2.2.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("1.9.3"))).value.to_s
+      assert_match "ruby-1.8.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("1.8.7"))).value.to_s
+      assert_match "ruby-1.9.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("1.9.3"))).value.to_s
+      assert_match "ruby-2.0.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("2.0.0"))).value.to_s
+      assert_match "ruby-2.1.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("2.1.10"))).value.to_s
+      assert_match "ruby-2.2.yml", @subject.rules(LintRoller::Context.new(target_ruby_version: Gem::Version.new("2.2.10"))).value.to_s
     end
   end
 end


### PR DESCRIPTION
- Performance/EndWith
- Performance/StartWith
- Performance/DoubleStartEndWith
- Also, inherit rules disabled in newer, but still old, rubies, e.g. ruby-2.2.yml