### PR TITLE
Fix incompatibility with betterlint

### DIFF
--- a/standard-performance.gemspec
+++ b/standard-performance.gemspec
@@ -29,5 +29,5 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "lint_roller", "~> 1.1"
-  spec.add_dependency "rubocop-performance", "~> 1.20.2"
+  spec.add_dependency "rubocop-performance", "~> 1.21.0"
 end


### PR DESCRIPTION
Align rubocop-performance version requirement with latest betterlint v1.9 i.e. stop blocking betterlint upgrades