### PR TITLE
Drop EOL ruby versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        ruby-version: [2.7, '3.0', 3.1, 3.2]
+        ruby-version:
+          - '3.1'
+          - '3.2'
+          - '3.3'
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby-version }}
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby-version }}
-          bundler-cache: false # <-- Can reenable this after dropping 2.7
+          bundler-cache: true
       - name: Install dependencies
         run: bundle install
       - name: Run tests for Ruby ${{ matrix.ruby-version }} on ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         ruby-version:
+          - '3.0'
           - '3.1'
           - '3.2'
           - '3.3'

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,4 @@ gem "rake"
 gem "minitest"
 gem "standard"
 gem "m"
-
-# Remove branch after 2.7 is dropped
-if RUBY_VERSION > "3"
-  gem "mocktail"
-end
+gem "mocktail"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,6 +17,9 @@ GEM
       rake (>= 0.9.2.2)
     method_source (1.0.0)
     minitest (5.19.0)
+    mocktail (2.0.0)
+      sorbet-eraser (~> 0.3.1)
+      sorbet-runtime (~> 0.5.9204)
     parallel (1.24.0)
     parser (3.3.1.0)
       ast (~> 2.4.1)
@@ -43,6 +46,8 @@ GEM
       rubocop (>= 1.48.1, < 2.0)
       rubocop-ast (>= 1.31.1, < 2.0)
     ruby-progressbar (1.13.0)
+    sorbet-eraser (0.3.1)
+    sorbet-runtime (0.5.11435)
     standard (1.33.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -62,6 +67,7 @@ PLATFORMS
 DEPENDENCIES
   m
   minitest
+  mocktail
   rake
   standard
   standard-performance!

--- a/standard-performance.gemspec
+++ b/standard-performance.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Standard Ruby Plugin providing configuration for rubocop-performance"
   spec.homepage = "https://github.com/standardrb/standard-performance"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.7.0"
+  spec.required_ruby_version = ">= 3.0.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage

--- a/test/standard/performance/builds_ruleset_test.rb
+++ b/test/standard/performance/builds_ruleset_test.rb
@@ -1,8 +1,5 @@
 require "test_helper"
 
-# Remove after 2.7 is dropped
-return unless RUBY_VERSION > "3"
-
 module Standard::Performance
   class BuildsRulesetTest < Minitest::Test
     def setup

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,15 +3,12 @@ require "standard/performance"
 
 require "minitest/autorun"
 
-# Remove branch after 2.7 is dropped
-if RUBY_VERSION > "3"
-  require "mocktail"
+require "mocktail"
 
-  class Minitest::Test
-    include Mocktail::DSL
+class Minitest::Test
+  include Mocktail::DSL
 
-    def teardown
-      Mocktail.reset
-    end
+  def teardown
+    Mocktail.reset
   end
 end


### PR DESCRIPTION
From the studio that brought you https://github.com/standardrb/standard/pull/633 and https://github.com/standardrb/standard-rails/pull/42 comes ... this PR.

- Bump actions/checkout on CI (removes deprecation warning)
- Drop EOL rubyies (2.7 and 3.0) from CI config
- Add latest stable (3.3) ruby to CI config
- Drop various ruby-2.7-specific conditional checks around gem/test/etc

I did NOT yet bump the required ruby version in the gemspec ...  can do so here or in subsequent PR if desired.