### PR TITLE
Gemfile can be versionless

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source "https://rubygems.org"
 
 gemspec
+
 gem "m"
 gem "minitest"
 gem "mocktail"
 gem "rake"
 gem "simplecov"
-gem "standard", "~>1.36"
+gem "standard"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,7 +81,7 @@ DEPENDENCIES
   mocktail
   rake
   simplecov
-  standard (~> 1.36)
+  standard
   standard-performance!
 
 BUNDLED WITH


### PR DESCRIPTION
Ideally, the only version specs in the Gemfile should be upper-bound
versions that are _known_ to be incompatible. Everything else can
(should) be controlled by the lockfile.

fixes https://github.com/standardrb/standard-performance/pull/33#issuecomment-2842180156
